### PR TITLE
Fix ELOOP & Readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ WORKDIR /bp
 COPY . /bp/modules/channel-rocketchat
 RUN yarn && \
     yarn build && \ 
+    rm -fR /bp/modules/channel-rocketchat/node_production_modules/asteroid/test && \
     yarn package

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ WORKDIR /bp
 COPY . /bp/modules/channel-rocketchat
 RUN yarn && \
     yarn build && \ 
-    rm -fR /bp/modules/channel-rocketchat/node_production_modules/asteroid/test && \
+    rm -fR "/usr/local/share/.cache/yarn/v6/npm-asteroid*/node_modules/asteroid/test" && \
     yarn package

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This is the module integration between Botpress and Rocket.Chat
 git clone https://github.com/metsrl/channel-rocketchat.git
 cd channel-rocketchat
 docker build -t channel --no-cache .
-docker run -v "$(pwd)":/out --rm channel bash -c "cp /bp/out/binaries/modules/channel-rocketchat.tgz /out/"
+docker run -v "$(pwd)":/out --rm channel bash -c "cp /bp/packages/bp/binaries/modules/channel-rocketchat.tgz /out/"
 echo && echo "There you go:" && ls -lh channel-rocketchat.tgz
 ```
 Then, put the *channel-rocketchat.tgz* inside your production "<BP_ROOT>/modules" and restart you BP. 


### PR DESCRIPTION
Fixing the ELOOP error coming from the symlink inside the `asteroid` lib, related to issue #3 .
Also, fixing the path of the package on the README. 